### PR TITLE
Improve the search bar keyboard controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -183,12 +183,12 @@ function Home() {
     // Keyboard shortcut for search overlay (cmd+k / ctrl+j)
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.metaKey && e.key === "k") || (e.ctrlKey && e.key === "j")) {
+            if ((e.metaKey && e.key === "k") || (e.ctrlKey && e.key === "j") || (!e.metaKey && !e.ctrlKey && e.key === "/")) {
                 e.preventDefault();
                 setShowSearchOverlay(true);
                 trackUmamiEvent("search_overlay_opened", {
                     source: "keyboard_shortcut",
-                    shortcut: e.metaKey && e.key === "k" ? "cmd+k" : "ctrl+j",
+                    shortcut: e.key === "/" ? "/" : (e.metaKey && e.key === "k" ? "cmd+k" : "ctrl+j"),
                 });
             }
         };

--- a/components/search/SearchBarOverlay/SearchBarOverlay.tsx
+++ b/components/search/SearchBarOverlay/SearchBarOverlay.tsx
@@ -92,6 +92,7 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
     const { t, ready } = useTranslation();
     const [searchQuery, setSearchQuery] = useState("");
     const [filteredResults, setFilteredResults] = useState<SearchResult[]>([]);
+    const [activeResultIndex, setActiveResultIndex] = useState(-1);
     const searchInputRef = useRef<HTMLInputElement>(null);
 
     // Memoize normalized vehicles data
@@ -188,6 +189,7 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
     const handleClose = () => {
         setSearchQuery("");
         setFilteredResults([]);
+        setActiveResultIndex(-1);
         onClose();
     };
 
@@ -207,10 +209,22 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
             handleClose();
         }
 
-        if (e.key === "Enter" && filteredResults.length > 0) {
-            e.preventDefault();
-            e.stopPropagation();
-            handleResultClick(filteredResults[0]);
+        if (filteredResults.length > 0) {
+            switch (e.key) {
+                case "Enter":
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleResultClick(filteredResults[activeResultIndex] ?? filteredResults[0]);
+                    break;
+                case "ArrowUp":
+                    e.preventDefault();
+                    setActiveResultIndex(cur => cur <= 0 ? filteredResults.length - 1 : cur - 1);
+                    break;
+                case "ArrowDown":
+                    e.preventDefault();
+                    setActiveResultIndex(cur => cur >= filteredResults.length - 1 ? 0 : cur + 1);
+                    break;
+            }
         }
     };
 
@@ -287,6 +301,8 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
                             <div className="space-y-3 mt-4">
                                 {filteredResults.map(
                                     (result: SearchResult, index) => {
+                                        const isActive = index === activeResultIndex;
+                                        const baseClasses = `bg-[#1e1e1e] backdrop-blur-sm rounded-2xl p-4 cursor-pointer hover:bg-[#2e2e2e] dark:hover:bg-gray-800 hover:shadow-lg transition-all duration-200 hover:scale-[1.02] animate-in slide-in-from-top-2 fade-in ${isActive ? "bg-[#2e2e2e] ring-2 ring-green-800" : ""}`;
                                         if (result.type === "vehicle") {
                                             const vehicle = result.data;
                                             return (
@@ -297,10 +313,7 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
                                                             result,
                                                         )
                                                     }
-                                                    className={`bg-[#1e1e1e] backdrop-blur-sm rounded-2xl p-4 cursor-pointer 
-                                  hover:bg-[#2e2e2e] dark:hover:bg-gray-800 hover:shadow-lg 
-                                   transition-all duration-200 hover:scale-[1.02]
-                                  animate-in slide-in-from-top-2 fade-in`}
+                                                    className={baseClasses}
                                                     style={{
                                                         animationDelay: `${
                                                             index * 50
@@ -502,10 +515,7 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
                                                             result,
                                                         )
                                                     }
-                                                    className={`bg-[#1e1e1e] backdrop-blur-sm rounded-2xl p-4 cursor-pointer 
-                                  hover:bg-[#2e2e2e] dark:hover:bg-gray-800 hover:shadow-lg 
-                                   transition-all duration-200 hover:scale-[1.02]
-                                  animate-in slide-in-from-top-2 fade-in`}
+                                                    className={baseClasses}
                                                     style={{
                                                         animationDelay: `${
                                                             index * 50

--- a/components/search/SearchBarOverlay/SearchBarOverlay.tsx
+++ b/components/search/SearchBarOverlay/SearchBarOverlay.tsx
@@ -94,6 +94,7 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
     const [filteredResults, setFilteredResults] = useState<SearchResult[]>([]);
     const [activeResultIndex, setActiveResultIndex] = useState(-1);
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const resultRefs = useRef<Array<HTMLElement | null>>([]);
 
     // Memoize normalized vehicles data
     const normalizedVehicles = useMemo(
@@ -185,6 +186,18 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
         }
         setFilteredResults(combined);
     }, [searchQuery, normalizedVehicles, normalizedStations]);
+
+    useEffect(() => {
+        resultRefs.current = resultRefs.current.slice(0, filteredResults.length);
+        setActiveResultIndex(-1);
+    }, [filteredResults.length, searchQuery]);
+
+    useEffect(() => {
+        resultRefs.current[activeResultIndex]?.scrollIntoView({
+            block: "nearest",
+            behavior: "smooth",
+        });
+    }, [activeResultIndex]);
 
     const handleClose = () => {
         setSearchQuery("");
@@ -308,11 +321,9 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
                                             return (
                                                 <div
                                                     key={`vehicle-${vehicle.trainNumber}`}
-                                                    onClick={() =>
-                                                        handleResultClick(
-                                                            result,
-                                                        )
-                                                    }
+                                                    ref={el => resultRefs.current[index] = el}
+                                                    onClick={() => handleResultClick(result) }
+                                                    onMouseEnter={() => setActiveResultIndex(index) }
                                                     className={baseClasses}
                                                     style={{
                                                         animationDelay: `${
@@ -510,11 +521,9 @@ const SearchOverlay: React.FC<SearchOverlayProps> = ({
                                             return (
                                                 <div
                                                     key={`station-${station.code}`}
-                                                    onClick={() =>
-                                                        handleResultClick(
-                                                            result,
-                                                        )
-                                                    }
+                                                    ref={el => resultRefs.current[index] = el}
+                                                    onClick={() => handleResultClick(result) }
+                                                    onMouseEnter={() => setActiveResultIndex(index) }
                                                     className={baseClasses}
                                                     style={{
                                                         animationDelay: `${


### PR DESCRIPTION
_I'm writing this in English since everything else seems to do so too, but let me know if you'd rather engage in Portuguese instead!_

I've been using comboios.live for a while and the keyboard controls for the search bar have always bothered me slightly. Today (while riding on a train, no less!), I finally spent a bit tweaking it.

In short, the changes are just:

- the search bar can now be triggered with `/`
- results can now be highlighted with the arrow keys (up and down), and then selected with Enter.

I've tested this locally, by configuring a `.env.local` with 
```env
WORKER_BASE_URL=https://comboios.live/api
```
And tweaking the vehicles route to use `WORKER_BASE_URL/vehicles?excludes=completed` instead. Then ran with `bun run dev`. 